### PR TITLE
Adjust Hacienda module version for Odoo 19

### DIFF
--- a/hacienda/__init__.py
+++ b/hacienda/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/hacienda/__manifest__.py
+++ b/hacienda/__manifest__.py
@@ -1,0 +1,28 @@
+{
+    "name": "Hacienda - Costa Rica Electronic Invoicing",
+    "summary": "Adds Costa Rican electronic invoicing support (XML 4.4) for Odoo 19.",
+    "description": """Costa Rican localization helpers for electronic invoicing (XML schema 4.4).\nIncludes journals, taxes, products, partners and electronic document management.""",
+    "version": "19.0.1.0.0",
+    "category": "Accounting",
+    "author": "OpenAI Assistant",
+    "website": "https://www.hacienda.go.cr/",
+    "license": "LGPL-3",
+    "depends": [
+        "base",
+        "account",
+        "contacts",
+        "product",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "data/hacienda_menus.xml",
+        "views/account_journal_views.xml",
+        "views/account_tax_views.xml",
+        "views/product_template_views.xml",
+        "views/res_partner_views.xml",
+        "views/hacienda_config_views.xml",
+        "views/hacienda_document_views.xml",
+        "views/hacienda_catalog_views.xml",
+    ],
+    "application": True,
+}

--- a/hacienda/data/hacienda_menus.xml
+++ b/hacienda/data/hacienda_menus.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <menuitem id="menu_hacienda_root" name="Hacienda" sequence="60" parent="account.menu_finance"/>
+
+    <record id="action_hacienda_electronic_documents" model="ir.actions.act_window">
+        <field name="name">Comprobantes electrónicos</field>
+        <field name="res_model">hacienda.electronic.document</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_hacienda_documents" name="Comprobantes" parent="menu_hacienda_root" action="action_hacienda_electronic_documents"/>
+
+    <record id="action_hacienda_config_settings" model="ir.actions.act_window">
+        <field name="name">Configuración Hacienda</field>
+        <field name="res_model">res.config.settings</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="context">{'module' : 'hacienda', 'default_hacienda_api_base_url': True}</field>
+    </record>
+
+    <menuitem id="menu_hacienda_configuration" name="Configuración" parent="menu_hacienda_root" sequence="20" action="action_hacienda_config_settings"/>
+
+    <record id="action_hacienda_cabys" model="ir.actions.act_window">
+        <field name="name">Catálogo CABYS</field>
+        <field name="res_model">hacienda.cabys</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_hacienda_cabys" name="CABYS" parent="menu_hacienda_root" sequence="30" action="action_hacienda_cabys"/>
+
+    <record id="action_hacienda_measurement_units" model="ir.actions.act_window">
+        <field name="name">Unidades Hacienda</field>
+        <field name="res_model">hacienda.measurement.unit</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_hacienda_measurement_units" name="Unidades de Medida" parent="menu_hacienda_root" sequence="40" action="action_hacienda_measurement_units"/>
+
+    <record id="action_hacienda_cantons" model="ir.actions.act_window">
+        <field name="name">Cantones</field>
+        <field name="res_model">hacienda.canton</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <record id="action_hacienda_districts" model="ir.actions.act_window">
+        <field name="name">Distritos</field>
+        <field name="res_model">hacienda.district</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <record id="action_hacienda_neighborhoods" model="ir.actions.act_window">
+        <field name="name">Barrios</field>
+        <field name="res_model">hacienda.neighborhood</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_hacienda_geo" name="Ubicaciones" parent="menu_hacienda_root" sequence="50"/>
+    <menuitem id="menu_hacienda_geo_cantons" name="Cantones" parent="menu_hacienda_geo" action="action_hacienda_cantons"/>
+    <menuitem id="menu_hacienda_geo_districts" name="Distritos" parent="menu_hacienda_geo" action="action_hacienda_districts"/>
+    <menuitem id="menu_hacienda_geo_neighborhoods" name="Barrios" parent="menu_hacienda_geo" action="action_hacienda_neighborhoods"/>
+</odoo>

--- a/hacienda/models/__init__.py
+++ b/hacienda/models/__init__.py
@@ -1,0 +1,7 @@
+from . import account_journal
+from . import account_tax
+from . import product_template
+from . import res_partner
+from . import hacienda_config
+from . import hacienda_document
+from . import hacienda_catalog

--- a/hacienda/models/account_journal.py
+++ b/hacienda/models/account_journal.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    cr_use_xml_44 = fields.Boolean(
+        string="Usa documentos electrónicos XML 4.4",
+        help="Active esta opción para habilitar la facturación electrónica de Costa Rica en este diario.",
+    )
+    cr_electronic_document_type = fields.Selection(
+        selection=lambda self: self.env["account.journal"]._selection_cr_electronic_document_type(),
+        string="Tipo de documento electrónico",
+        help="Tipo de comprobante electrónico que se emitirá desde este diario.",
+    )
+
+    @staticmethod
+    def _selection_cr_electronic_document_type():
+        return [
+            ("FE", "Factura Electrónica"),
+            ("TE", "Tiquete Electrónico"),
+            ("FEE", "Factura Electrónica de Exportación"),
+            ("NC", "Nota de Crédito"),
+            ("ND", "Nota de Débito"),
+            ("CCE", "Confirmación de Comprobante Electrónico"),
+            ("CPCE", "Confirmación Parcial"),
+            ("RCE", "Rechazo de Comprobante"),
+        ]

--- a/hacienda/models/account_tax.py
+++ b/hacienda/models/account_tax.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class AccountTax(models.Model):
+    _inherit = "account.tax"
+
+    cr_tax_type = fields.Selection(
+        selection=lambda self: self.env["account.tax"]._selection_cr_tax_type(),
+        string="Tipo de impuesto (CR)",
+        help="Clasificación del impuesto según Hacienda (IVA, Selectivo de Consumo, etc.)",
+    )
+    cr_tax_rate = fields.Selection(
+        selection=lambda self: self.env["account.tax"]._selection_cr_tax_rate(),
+        string="Tarifa Hacienda",
+        help="Tarifa oficial del impuesto definida por Hacienda.",
+    )
+
+    @staticmethod
+    def _selection_cr_tax_type():
+        return [
+            ("IVA", "Impuesto al Valor Agregado"),
+            ("ISC", "Impuesto Selectivo de Consumo"),
+            ("IM", "Impuesto Municipal"),
+            ("OT", "Otros"),
+        ]
+
+    @staticmethod
+    def _selection_cr_tax_rate():
+        return [
+            ("exento", "Exento"),
+            ("0", "0%"),
+            ("1", "1%"),
+            ("2", "2%"),
+            ("4", "4%"),
+            ("8", "8%"),
+            ("13", "13%"),
+        ]

--- a/hacienda/models/hacienda_catalog.py
+++ b/hacienda/models/hacienda_catalog.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class HaciendaCabys(models.Model):
+    _name = "hacienda.cabys"
+    _description = "Catálogo CABYS"
+    _order = "code"
+
+    code = fields.Char(string="Código", required=True, index=True)
+    name = fields.Char(string="Descripción", required=True)
+    tax_rate = fields.Selection(
+        selection=lambda self: self.env["account.tax"]._selection_cr_tax_rate(),
+        string="Tarifa por defecto",
+    )
+    active = fields.Boolean(default=True)
+
+    _sql_constraints = [
+        ("hacienda_cabys_code_unique", "unique(code)", "El código CABYS debe ser único."),
+    ]
+
+
+class HaciendaMeasurementUnit(models.Model):
+    _name = "hacienda.measurement.unit"
+    _description = "Unidades de medida Hacienda"
+    _order = "code"
+
+    code = fields.Char(string="Código", required=True, index=True)
+    name = fields.Char(string="Nombre", required=True)
+    uom_id = fields.Many2one(
+        comodel_name="uom.uom",
+        string="Unidad Odoo equivalente",
+        help="Unidad de medida en Odoo que corresponde a la unidad oficial de Hacienda.",
+    )
+
+    _sql_constraints = [
+        ("hacienda_measurement_unit_code_unique", "unique(code)", "El código de unidad debe ser único."),
+    ]
+
+
+class HaciendaCanton(models.Model):
+    _name = "hacienda.canton"
+    _description = "Cantones Hacienda"
+    _order = "code"
+
+    code = fields.Char(string="Código", required=True, index=True)
+    name = fields.Char(string="Nombre", required=True)
+    province_id = fields.Many2one(
+        comodel_name="res.country.state",
+        string="Provincia",
+        help="Provincia a la que pertenece el cantón.",
+    )
+
+    _sql_constraints = [
+        ("hacienda_canton_code_unique", "unique(code)", "El código del cantón debe ser único."),
+    ]
+
+
+class HaciendaDistrict(models.Model):
+    _name = "hacienda.district"
+    _description = "Distritos Hacienda"
+    _order = "code"
+
+    code = fields.Char(string="Código", required=True, index=True)
+    name = fields.Char(string="Nombre", required=True)
+    canton_id = fields.Many2one(
+        comodel_name="hacienda.canton",
+        string="Cantón",
+        required=True,
+        ondelete="cascade",
+    )
+
+    _sql_constraints = [
+        ("hacienda_district_code_unique", "unique(code)", "El código del distrito debe ser único."),
+    ]
+
+
+class HaciendaNeighborhood(models.Model):
+    _name = "hacienda.neighborhood"
+    _description = "Barrios Hacienda"
+    _order = "code"
+
+    code = fields.Char(string="Código", required=True, index=True)
+    name = fields.Char(string="Nombre", required=True)
+    district_id = fields.Many2one(
+        comodel_name="hacienda.district",
+        string="Distrito",
+        required=True,
+        ondelete="cascade",
+    )
+
+    _sql_constraints = [
+        ("hacienda_neighborhood_code_unique", "unique(code)", "El código del barrio debe ser único."),
+    ]

--- a/hacienda/models/hacienda_config.py
+++ b/hacienda/models/hacienda_config.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    hacienda_api_base_url = fields.Char(string="URL API Hacienda")
+    hacienda_cert_key = fields.Binary(string="Llave criptográfica")
+    hacienda_cert_key_filename = fields.Char(string="Nombre archivo certificado")
+    hacienda_username = fields.Char(string="Usuario Hacienda")
+    hacienda_password = fields.Char(string="Contraseña Hacienda")
+    hacienda_certificate_pin = fields.Char(string="PIN Certificado")
+
+
+class HaciendaResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    hacienda_api_base_url = fields.Char(related="company_id.hacienda_api_base_url", readonly=False)
+    hacienda_cert_key = fields.Binary(related="company_id.hacienda_cert_key", readonly=False)
+    hacienda_cert_key_filename = fields.Char(string="Nombre archivo certificado")
+    hacienda_username = fields.Char(related="company_id.hacienda_username", readonly=False)
+    hacienda_password = fields.Char(related="company_id.hacienda_password", readonly=False)
+    hacienda_certificate_pin = fields.Char(related="company_id.hacienda_certificate_pin", readonly=False)

--- a/hacienda/models/hacienda_document.py
+++ b/hacienda/models/hacienda_document.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class HaciendaElectronicDocument(models.Model):
+    _name = "hacienda.electronic.document"
+    _description = "Documento electrónico Hacienda"
+    _order = "create_date desc"
+
+    name = fields.Char(string="Número documento", required=True)
+    move_id = fields.Many2one(
+        comodel_name="account.move",
+        string="Factura relacionada",
+        ondelete="set null",
+    )
+    journal_id = fields.Many2one(
+        related="move_id.journal_id",
+        store=True,
+        string="Diario",
+        readonly=True,
+    )
+    state = fields.Selection(
+        [
+            ("draft", "Borrador"),
+            ("sent", "Enviado"),
+            ("accepted", "Aceptado"),
+            ("rejected", "Rechazado"),
+            ("error", "Error"),
+        ],
+        string="Estado",
+        default="draft",
+    )
+    xml_filename = fields.Char(string="Nombre XML")
+    xml_file = fields.Binary(string="Archivo XML")
+    xml_response_filename = fields.Char(string="Nombre respuesta")
+    xml_response = fields.Binary(string="Respuesta Hacienda")
+    send_date = fields.Datetime(string="Fecha envío")
+    response_date = fields.Datetime(string="Fecha respuesta")
+    message = fields.Text(string="Mensaje Hacienda")

--- a/hacienda/models/product_template.py
+++ b/hacienda/models/product_template.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    cabys_code_id = fields.Many2one(
+        comodel_name="hacienda.cabys",
+        string="Código CABYS",
+        help="Código estándar de bienes y servicios (CABYS) provisto por Hacienda.",
+    )
+    hacienda_measurement_unit_id = fields.Many2one(
+        comodel_name="hacienda.measurement.unit",
+        string="Unidad de medida Hacienda",
+        help="Unidad de medida oficial según el catálogo de Hacienda.",
+    )

--- a/hacienda/models/res_partner.py
+++ b/hacienda/models/res_partner.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+import logging
+
+import requests
+
+from odoo import fields, models
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    hacienda_canton_id = fields.Many2one(
+        comodel_name="hacienda.canton",
+        string="Cantón",
+        help="Cantón según el catálogo oficial de Hacienda.",
+    )
+    hacienda_district_id = fields.Many2one(
+        comodel_name="hacienda.district",
+        string="Distrito",
+        help="Distrito según el catálogo oficial de Hacienda.",
+    )
+    hacienda_neighborhood_id = fields.Many2one(
+        comodel_name="hacienda.neighborhood",
+        string="Barrio",
+        help="Barrio según el catálogo oficial de Hacienda.",
+    )
+    hacienda_identification_type = fields.Selection(
+        selection=lambda self: self.env["res.partner"]._selection_hacienda_identification_type(),
+        string="Tipo de identificación Hacienda",
+    )
+    hacienda_identification = fields.Char(string="Número identificación Hacienda")
+
+    @staticmethod
+    def _selection_hacienda_identification_type():
+        return [
+            ("fisica", "Cédula Física"),
+            ("juridica", "Cédula Jurídica"),
+            ("dimex", "DIMEX"),
+            ("nite", "NITE"),
+            ("extranjero", "Identificación Extranjera"),
+        ]
+
+    def action_fetch_hacienda_identification(self):
+        for partner in self:
+            if not partner.hacienda_identification:
+                raise UserError("Debe indicar el número de identificación antes de consultar a Hacienda.")
+
+            company = partner.company_id or self.env.company
+            base_url = company.hacienda_api_base_url
+            if not base_url:
+                raise UserError("Configure la URL del API de Hacienda en Ajustes > Hacienda.")
+
+            endpoint = f"{base_url.rstrip('/')}/identificacion/{partner.hacienda_identification}"
+            try:
+                response = requests.get(endpoint, timeout=30)
+                response.raise_for_status()
+            except requests.RequestException as exc:
+                _logger.exception("Error consultando Hacienda: %s", exc)
+                raise UserError("No fue posible obtener la información desde Hacienda.")
+
+            data = response.json() if response.content else {}
+            if not data:
+                raise UserError("Hacienda no retornó información para la identificación indicada.")
+
+            partner_values = {}
+            name = data.get("nombre") or data.get("name")
+            if name:
+                partner_values["name"] = name
+
+            email = data.get("email")
+            if email:
+                partner_values["email"] = email
+
+            phone = data.get("telefono") or data.get("phone")
+            if phone:
+                partner_values["phone"] = phone
+
+            address = data.get("direccion") or {}
+            if address:
+                partner_values.update(
+                    {
+                        "street": address.get("linea1") or address.get("street"),
+                        "zip": address.get("codigo_postal") or address.get("zip"),
+                    }
+                )
+                canton_code = address.get("canton")
+                district_code = address.get("distrito")
+                neighborhood_code = address.get("barrio")
+
+                if canton_code:
+                    canton = self.env["hacienda.canton"].search([("code", "=", canton_code)], limit=1)
+                    if canton:
+                        partner_values["hacienda_canton_id"] = canton.id
+
+                if district_code:
+                    district = self.env["hacienda.district"].search([("code", "=", district_code)], limit=1)
+                    if district:
+                        partner_values["hacienda_district_id"] = district.id
+
+                if neighborhood_code:
+                    neighborhood = self.env["hacienda.neighborhood"].search([("code", "=", neighborhood_code)], limit=1)
+                    if neighborhood:
+                        partner_values["hacienda_neighborhood_id"] = neighborhood.id
+
+            if partner_values:
+                partner.write(partner_values)

--- a/hacienda/security/ir.model.access.csv
+++ b/hacienda/security/ir.model.access.csv
@@ -1,0 +1,7 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_hacienda_electronic_document_user,Hacienda Electronic Document,model_hacienda_electronic_document,base.group_user,1,1,1,0
+access_hacienda_cabys_user,Hacienda CABYS,model_hacienda_cabys,base.group_user,1,0,0,0
+access_hacienda_measurement_unit_user,Hacienda Measurement Unit,model_hacienda_measurement_unit,base.group_user,1,0,0,0
+access_hacienda_canton_user,Hacienda Canton,model_hacienda_canton,base.group_user,1,0,0,0
+access_hacienda_district_user,Hacienda District,model_hacienda_district,base.group_user,1,0,0,0
+access_hacienda_neighborhood_user,Hacienda Neighborhood,model_hacienda_neighborhood,base.group_user,1,0,0,0

--- a/hacienda/views/account_journal_views.xml
+++ b/hacienda/views/account_journal_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_account_journal_form_hacienda" model="ir.ui.view">
+        <field name="name">account.journal.form.hacienda</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='invoicing']" position="inside">
+                <group string="Hacienda">
+                    <field name="cr_use_xml_44"/>
+                    <field name="cr_electronic_document_type" attrs="{'required': [('cr_use_xml_44', '=', True)]}"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/hacienda/views/account_tax_views.xml
+++ b/hacienda/views/account_tax_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_account_tax_form_hacienda" model="ir.ui.view">
+        <field name="name">account.tax.form.hacienda</field>
+        <field name="model">account.tax</field>
+        <field name="inherit_id" ref="account.view_account_tax_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='options']" position="inside">
+                <group string="Hacienda">
+                    <field name="cr_tax_type"/>
+                    <field name="cr_tax_rate"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/hacienda/views/hacienda_catalog_views.xml
+++ b/hacienda/views/hacienda_catalog_views.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_hacienda_cabys_tree" model="ir.ui.view">
+        <field name="name">hacienda.cabys.tree</field>
+        <field name="model">hacienda.cabys</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="code"/>
+                <field name="name"/>
+                <field name="tax_rate"/>
+                <field name="active"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_hacienda_cabys_form" model="ir.ui.view">
+        <field name="name">hacienda.cabys.form</field>
+        <field name="model">hacienda.cabys</field>
+        <field name="arch" type="xml">
+            <form string="Código CABYS">
+                <sheet>
+                    <group>
+                        <field name="code"/>
+                        <field name="name"/>
+                        <field name="tax_rate"/>
+                        <field name="active"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_hacienda_measurement_unit_tree" model="ir.ui.view">
+        <field name="name">hacienda.measurement.unit.tree</field>
+        <field name="model">hacienda.measurement.unit</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="code"/>
+                <field name="name"/>
+                <field name="uom_id"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_hacienda_measurement_unit_form" model="ir.ui.view">
+        <field name="name">hacienda.measurement.unit.form</field>
+        <field name="model">hacienda.measurement.unit</field>
+        <field name="arch" type="xml">
+            <form string="Unidad Hacienda">
+                <sheet>
+                    <group>
+                        <field name="code"/>
+                        <field name="name"/>
+                        <field name="uom_id"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_hacienda_canton_tree" model="ir.ui.view">
+        <field name="name">hacienda.canton.tree</field>
+        <field name="model">hacienda.canton</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="code"/>
+                <field name="name"/>
+                <field name="province_id"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_hacienda_canton_form" model="ir.ui.view">
+        <field name="name">hacienda.canton.form</field>
+        <field name="model">hacienda.canton</field>
+        <field name="arch" type="xml">
+            <form string="Cantón">
+                <sheet>
+                    <group>
+                        <field name="code"/>
+                        <field name="name"/>
+                        <field name="province_id"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_hacienda_district_tree" model="ir.ui.view">
+        <field name="name">hacienda.district.tree</field>
+        <field name="model">hacienda.district</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="code"/>
+                <field name="name"/>
+                <field name="canton_id"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_hacienda_district_form" model="ir.ui.view">
+        <field name="name">hacienda.district.form</field>
+        <field name="model">hacienda.district</field>
+        <field name="arch" type="xml">
+            <form string="Distrito">
+                <sheet>
+                    <group>
+                        <field name="code"/>
+                        <field name="name"/>
+                        <field name="canton_id"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_hacienda_neighborhood_tree" model="ir.ui.view">
+        <field name="name">hacienda.neighborhood.tree</field>
+        <field name="model">hacienda.neighborhood</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="code"/>
+                <field name="name"/>
+                <field name="district_id"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_hacienda_neighborhood_form" model="ir.ui.view">
+        <field name="name">hacienda.neighborhood.form</field>
+        <field name="model">hacienda.neighborhood</field>
+        <field name="arch" type="xml">
+            <form string="Barrio">
+                <sheet>
+                    <group>
+                        <field name="code"/>
+                        <field name="name"/>
+                        <field name="district_id"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/hacienda/views/hacienda_config_views.xml
+++ b/hacienda/views/hacienda_config_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_res_config_settings_hacienda" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.hacienda</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base.view_res_config_settings"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='settings']/div" position="inside">
+                <div class="app_settings_block" data-string="Hacienda" string="Hacienda" groups="base.group_system">
+                    <h2>Facturación electrónica Costa Rica</h2>
+                    <group>
+                        <field name="hacienda_api_base_url" placeholder="https://api.comprobanteselectronicos.go.cr"/>
+                        <field name="hacienda_username"/>
+                        <field name="hacienda_password" password="True"/>
+                        <field name="hacienda_certificate_pin" password="True"/>
+                        <field name="hacienda_cert_key" filename="hacienda_cert_key_filename" widget="binary" options="{'no_open': True}"/>
+                    </group>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/hacienda/views/hacienda_document_views.xml
+++ b/hacienda/views/hacienda_document_views.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_hacienda_electronic_document_tree" model="ir.ui.view">
+        <field name="name">hacienda.electronic.document.tree</field>
+        <field name="model">hacienda.electronic.document</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="move_id"/>
+                <field name="journal_id"/>
+                <field name="state"/>
+                <field name="send_date"/>
+                <field name="response_date"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_hacienda_electronic_document_form" model="ir.ui.view">
+        <field name="name">hacienda.electronic.document.form</field>
+        <field name="model">hacienda.electronic.document</field>
+        <field name="arch" type="xml">
+            <form string="Documento electrónico">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="move_id" options="{'no_open': False}"/>
+                        <field name="journal_id" readonly="1"/>
+                        <field name="state"/>
+                        <field name="send_date"/>
+                        <field name="response_date"/>
+                        <field name="message" widget="text" placeholder="Mensaje devuelto por Hacienda"/>
+                    </group>
+                    <notebook>
+                        <page string="XML enviado">
+                            <field name="xml_filename" readonly="1"/>
+                            <field name="xml_file" filename="xml_filename" widget="binary" options="{'no_create': True}"/>
+                        </page>
+                        <page string="Respuesta Hacienda">
+                            <field name="xml_response_filename" readonly="1"/>
+                            <field name="xml_response" filename="xml_response_filename" widget="binary" options="{'no_create': True}"/>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/hacienda/views/product_template_views.xml
+++ b/hacienda/views/product_template_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_product_template_form_hacienda" model="ir.ui.view">
+        <field name="name">product.template.form.hacienda</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='sales']" position="after">
+                <group string="Hacienda">
+                    <field name="cabys_code_id" options="{'no_open': False}"/>
+                    <field name="hacienda_measurement_unit_id" options="{'no_open': False}"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/hacienda/views/res_partner_views.xml
+++ b/hacienda/views/res_partner_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_res_partner_form_hacienda" model="ir.ui.view">
+        <field name="name">res.partner.form.hacienda</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='vat']" position="after">
+                <field name="hacienda_identification_type"/>
+                <field name="hacienda_identification"/>
+                <button name="action_fetch_hacienda_identification" type="object" string="Consultar Hacienda" class="oe_highlight"/>
+            </xpath>
+            <xpath expr="//group[@name='address']" position="inside">
+                <group string="Localización Hacienda">
+                    <field name="hacienda_canton_id" options="{'no_create': False}"/>
+                    <field name="hacienda_district_id" domain="[('canton_id', '=', hacienda_canton_id)]" options="{'no_create': False}"/>
+                    <field name="hacienda_neighborhood_id" domain="[('district_id', '=', hacienda_district_id)]" options="{'no_create': False}"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- add a new Hacienda module tailored to Costa Rican XML 4.4 electronic invoicing
- extend journals, taxes, products, and partners with Hacienda-specific fields and API integration helper
- provide configuration panels, catalogs, and document management menus for electronic comprobantes
- set the Hacienda module manifest version to 19.0.1.0.0 for Odoo 19 compatibility

## Testing
- not run (module scaffolding)


------
https://chatgpt.com/codex/tasks/task_e_68e5d6b98a3883269e3e30b6fdd0aa65