### PR TITLE
Avoid clearing address fields on partial Hacienda responses

### DIFF
--- a/hacienda/models/res_partner.py
+++ b/hacienda/models/res_partner.py
@@ -80,12 +80,18 @@ class ResPartner(models.Model):
 
             address = data.get("direccion") or {}
             if address:
-                partner_values.update(
-                    {
-                        "street": address.get("linea1") or address.get("street"),
-                        "zip": address.get("codigo_postal") or address.get("zip"),
-                    }
-                )
+                address_values = {}
+
+                street_value = address.get("linea1") or address.get("street")
+                if street_value:
+                    address_values["street"] = street_value
+
+                zip_value = address.get("codigo_postal") or address.get("zip")
+                if zip_value:
+                    address_values["zip"] = zip_value
+
+                if address_values:
+                    partner_values.update(address_values)
                 canton_code = address.get("canton")
                 district_code = address.get("distrito")
                 neighborhood_code = address.get("barrio")


### PR DESCRIPTION
## Summary
- skip updating partner street and zip when Hacienda omits those values
- preserve existing address data by only merging non-empty address fields from the API response

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5da41ad008326b272a9bd2c2f6da8