### PR TITLE
Fix journal hacienda view xpath for Odoo 19

### DIFF
--- a/hacienda/views/account_journal_views.xml
+++ b/hacienda/views/account_journal_views.xml
@@ -5,11 +5,13 @@
         <field name="model">account.journal</field>
         <field name="inherit_id" ref="account.view_account_journal_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='invoicing']" position="inside">
-                <group string="Hacienda">
-                    <field name="cr_use_xml_44"/>
-                    <field name="cr_electronic_document_type" attrs="{'required': [('cr_use_xml_44', '=', True)]}"/>
-                </group>
+            <xpath expr="//sheet/notebook" position="inside">
+                <page name="hacienda_settings" string="Hacienda">
+                    <group>
+                        <field name="cr_use_xml_44"/>
+                        <field name="cr_electronic_document_type" attrs="{'required': [('cr_use_xml_44', '=', True)]}"/>
+                    </group>
+                </page>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Summary
- adjust the Hacienda journal view inheritance to insert a dedicated page under the account journal notebook
- ensure the Hacienda-specific fields always render even when the invoicing group is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5f97032d08326abddd851ec11b2a9