### PR TITLE
Fix Hacienda tax view inheritance for advanced options

### DIFF
--- a/hacienda/views/account_tax_views.xml
+++ b/hacienda/views/account_tax_views.xml
@@ -5,7 +5,7 @@
         <field name="model">account.tax</field>
         <field name="inherit_id" ref="account.view_tax_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='options']" position="inside">
+            <xpath expr="//page[@name='advanced_options']/group" position="inside">
                 <group string="Hacienda">
                     <field name="cr_tax_type"/>
                     <field name="cr_tax_rate"/>


### PR DESCRIPTION
## Summary
- update the Hacienda tax form inheritance to target the advanced options page
- keep CR-specific fields displayed inside the tax form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e60ab9d12c8326b1516ac87e38a9bc