### PR TITLE
Fix Hacienda product template view xpath

### DIFF
--- a/hacienda/views/product_template_views.xml
+++ b/hacienda/views/product_template_views.xml
@@ -5,7 +5,7 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='sales']" position="after">
+            <xpath expr="//page[@name='sales']" position="inside">
                 <group string="Hacienda">
                     <field name="cabys_code_id" options="{'no_open': False}"/>
                     <field name="hacienda_measurement_unit_id" options="{'no_open': False}"/>


### PR DESCRIPTION
## Summary
- adjust the inherited product template form view to insert the Hacienda fields inside the sales page so the xpath resolves correctly during module installation

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e613d3a2508326b58662fbc42300b0