### PR TITLE
Fix Hacienda fields injection point on partner form

### DIFF
--- a/hacienda/views/res_partner_views.xml
+++ b/hacienda/views/res_partner_views.xml
@@ -10,7 +10,7 @@
                 <field name="hacienda_identification"/>
                 <button name="action_fetch_hacienda_identification" type="object" string="Consultar Hacienda" class="oe_highlight"/>
             </xpath>
-            <xpath expr="//group[@name='address']" position="inside">
+            <xpath expr="//group[.//field[@name='zip']]" position="inside">
                 <group string="Localización Hacienda">
                     <field name="hacienda_canton_id" options="{'no_create': False}"/>
                     <field name="hacienda_district_id" domain="[('canton_id', '=', hacienda_canton_id)]" options="{'no_create': False}"/>


### PR DESCRIPTION
## Summary
- update the partner form inheritance xpath to target the group containing the zip field
- ensure the Hacienda location fields can be inserted even when the address group lacks a name attribute

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e6155afca483268e925e208de242fe