### PR TITLE
Fix settings view inheritance for Odoo 17

### DIFF
--- a/hacienda/views/hacienda_config_views.xml
+++ b/hacienda/views/hacienda_config_views.xml
@@ -3,9 +3,9 @@
     <record id="view_res_config_settings_hacienda" model="ir.ui.view">
         <field name="name">res.config.settings.view.form.hacienda</field>
         <field name="model">res.config.settings</field>
-        <field name="inherit_id" ref="base.view_res_config_settings"/>
+        <field name="inherit_id" ref="base.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='settings']/div" position="inside">
+            <xpath expr="//div[@id='settings' or hasclass('settings')]" position="inside">
                 <div class="app_settings_block" data-string="Hacienda" string="Hacienda" groups="base.group_system">
                     <h2>Facturación electrónica Costa Rica</h2>
                     <group>


### PR DESCRIPTION
## Summary
- update the settings view inheritance to target the current base configuration view
- adjust the xpath to inject the Hacienda block into either legacy or new settings containers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6164ee94c8326bfe1f5eaf4e19a49