### PR TITLE
Align Hacienda catalogs with XML 4.4 requirements

### DIFF
--- a/hacienda/__manifest__.py
+++ b/hacienda/__manifest__.py
@@ -17,6 +17,7 @@
         "security/ir.model.access.csv",
         "data/hacienda_menus.xml",
         "views/account_journal_views.xml",
+        "views/account_move_views.xml",
         "views/account_tax_views.xml",
         "views/product_template_views.xml",
         "views/res_partner_views.xml",

--- a/hacienda/models/__init__.py
+++ b/hacienda/models/__init__.py
@@ -1,4 +1,5 @@
 from . import account_journal
+from . import account_move
 from . import account_tax
 from . import product_template
 from . import res_partner

--- a/hacienda/models/account_journal.py
+++ b/hacienda/models/account_journal.py
@@ -21,9 +21,11 @@ class AccountJournal(models.Model):
             ("FE", "Factura Electrónica"),
             ("TE", "Tiquete Electrónico"),
             ("FEE", "Factura Electrónica de Exportación"),
+            ("FEC", "Factura Electrónica de Compra"),
             ("NC", "Nota de Crédito"),
             ("ND", "Nota de Débito"),
             ("CCE", "Confirmación de Comprobante Electrónico"),
             ("CPCE", "Confirmación Parcial"),
             ("RCE", "Rechazo de Comprobante"),
+            ("REP", "Recibo Electrónico de Pago"),
         ]

--- a/hacienda/models/account_move.py
+++ b/hacienda/models/account_move.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    cr_sale_condition = fields.Selection(
+        selection=lambda self: self._selection_cr_sale_condition(),
+        string="Condición de venta (CR)",
+        help="Condición de venta exigida por Hacienda para los comprobantes electrónicos.",
+    )
+    cr_sale_condition_other = fields.Char(
+        string="Detalle condición de venta",
+        help="Detalle adicional requerido cuando se utiliza la condición 'Otros'.",
+    )
+    cr_credit_term = fields.Integer(
+        string="Plazo del crédito (días)",
+        help="Número de días de crédito cuando la condición de venta es crédito.",
+    )
+    cr_payment_method_line_ids = fields.One2many(
+        comodel_name="hacienda.move.payment.method",
+        inverse_name="move_id",
+        string="Medios de pago Hacienda",
+    )
+
+    @staticmethod
+    def _selection_cr_sale_condition():
+        return [
+            ("01", "Contado"),
+            ("02", "Crédito"),
+            ("03", "Consignación"),
+            ("04", "Apartado"),
+            ("05", "Arrendamiento con opción de compra"),
+            ("06", "Arrendamiento en función financiera"),
+            ("07", "Cobro a favor de un tercero"),
+            ("08", "Servicios prestados al Estado"),
+            ("09", "Pago de servicios prestado al Estado"),
+            ("10", "Venta a crédito en IVA hasta 90 días"),
+            ("11", "Pago de venta a crédito en IVA hasta 90 días"),
+            ("12", "Venta mercancía no nacionalizada"),
+            ("13", "Venta bienes usados no contribuyente"),
+            ("14", "Arrendamiento operativo"),
+            ("15", "Arrendamiento financiero"),
+            ("99", "Otros"),
+        ]
+
+    @api.constrains("cr_sale_condition", "cr_sale_condition_other")
+    def _check_sale_condition_other(self):
+        for move in self:
+            if move.cr_sale_condition == "99" and not move.cr_sale_condition_other:
+                raise ValidationError(
+                    "Debe detallar la condición de venta cuando seleccione la opción 'Otros'."
+                )
+
+    @api.constrains("cr_sale_condition", "cr_credit_term")
+    def _check_credit_term(self):
+        for move in self:
+            if move.cr_sale_condition in {"02", "10"}:
+                if move.cr_credit_term <= 0:
+                    raise ValidationError(
+                        "El plazo de crédito debe ser mayor a cero cuando la condición de venta es crédito."
+                    )
+            elif move.cr_credit_term and move.cr_sale_condition not in {"02", "10"}:
+                raise ValidationError(
+                    "El plazo de crédito solo puede informarse cuando la condición de venta es crédito."
+                )
+
+    @api.constrains("cr_sale_condition", "cr_payment_method_line_ids")
+    def _check_payment_methods(self):
+        for move in self:
+            if len(move.cr_payment_method_line_ids) > 4:
+                raise ValidationError("Solo se pueden indicar hasta cuatro medios de pago.")
+
+            if not move.cr_sale_condition:
+                continue
+
+            if not move.is_invoice(include_receipts=True):
+                continue
+
+            if move.cr_sale_condition not in {"02", "08", "10"} and not move.cr_payment_method_line_ids:
+                raise ValidationError(
+                    "Debe registrar al menos un medio de pago según las estructuras de Hacienda."
+                )
+
+
+class HaciendaMovePaymentMethod(models.Model):
+    _name = "hacienda.move.payment.method"
+    _description = "Medios de pago Hacienda"
+    _order = "sequence, id"
+
+    sequence = fields.Integer(default=10)
+    move_id = fields.Many2one(
+        comodel_name="account.move",
+        string="Comprobante",
+        required=True,
+        ondelete="cascade",
+    )
+    payment_method = fields.Selection(
+        selection=lambda self: self._selection_hacienda_payment_method(),
+        string="Medio de pago",
+        required=True,
+    )
+    description = fields.Char(
+        string="Detalle del medio de pago",
+        help="Detalle requerido cuando se selecciona el código 'Otros'.",
+    )
+    amount = fields.Monetary(
+        string="Monto",
+        currency_field="currency_id",
+        help="Monto asociado al medio de pago según Hacienda.",
+    )
+    currency_id = fields.Many2one(
+        comodel_name="res.currency",
+        related="move_id.currency_id",
+        store=True,
+        readonly=True,
+    )
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        related="move_id.company_id",
+        store=True,
+        readonly=True,
+    )
+
+    @staticmethod
+    def _selection_hacienda_payment_method():
+        return [
+            ("01", "Efectivo"),
+            ("02", "Tarjeta"),
+            ("03", "Cheque"),
+            ("04", "Transferencia o depósito bancario"),
+            ("05", "Recaudado por terceros"),
+            ("06", "SINPE Móvil"),
+            ("07", "Plataforma digital"),
+            ("99", "Otros"),
+        ]
+
+    @api.constrains("payment_method", "description")
+    def _check_description_required(self):
+        for line in self:
+            if line.payment_method == "99" and not line.description:
+                raise ValidationError(
+                    "Debe indicar el detalle del medio de pago cuando utilice el código 'Otros'."
+                )
+
+    @api.constrains("amount")
+    def _check_amount_positive(self):
+        for line in self:
+            if line.amount is not False and line.amount <= 0:
+                raise ValidationError("El monto del medio de pago debe ser mayor a cero.")

--- a/hacienda/models/account_tax.py
+++ b/hacienda/models/account_tax.py
@@ -19,20 +19,30 @@ class AccountTax(models.Model):
     @staticmethod
     def _selection_cr_tax_type():
         return [
-            ("IVA", "Impuesto al Valor Agregado"),
-            ("ISC", "Impuesto Selectivo de Consumo"),
-            ("IM", "Impuesto Municipal"),
-            ("OT", "Otros"),
+            ("01", "Impuesto al Valor Agregado"),
+            ("02", "Impuesto Selectivo de Consumo"),
+            ("03", "Impuesto Único a los Combustibles"),
+            ("04", "Impuesto específico de Bebidas Alcohólicas"),
+            ("05", "Impuesto Específico a Bebidas sin Alcohol y Jabones"),
+            ("06", "Impuesto a los Productos de Tabaco"),
+            ("07", "IVA (cálculo especial)"),
+            ("08", "IVA Régimen de Bienes Usados (Factor)"),
+            ("12", "Impuesto Específico al Cemento"),
+            ("99", "Otros"),
         ]
 
     @staticmethod
     def _selection_cr_tax_rate():
         return [
-            ("exento", "Exento"),
-            ("0", "0%"),
-            ("1", "1%"),
-            ("2", "2%"),
-            ("4", "4%"),
-            ("8", "8%"),
-            ("13", "13%"),
+            ("01", "Tarifa 0% (Art. 32 RLIVA)"),
+            ("02", "Tarifa reducida 1%"),
+            ("03", "Tarifa reducida 2%"),
+            ("04", "Tarifa reducida 4%"),
+            ("05", "Tarifa transitoria 0%"),
+            ("06", "Tarifa transitoria 4%"),
+            ("07", "Tarifa transitoria 8%"),
+            ("08", "Tarifa general 13%"),
+            ("09", "Tarifa reducida 0.5%"),
+            ("10", "Tarifa exenta"),
+            ("11", "Tarifa 0% sin derecho a crédito"),
         ]

--- a/hacienda/models/res_partner.py
+++ b/hacienda/models/res_partner.py
@@ -36,11 +36,12 @@ class ResPartner(models.Model):
     @staticmethod
     def _selection_hacienda_identification_type():
         return [
-            ("fisica", "Cédula Física"),
-            ("juridica", "Cédula Jurídica"),
-            ("dimex", "DIMEX"),
-            ("nite", "NITE"),
-            ("extranjero", "Identificación Extranjera"),
+            ("01", "Cédula Física"),
+            ("02", "Cédula Jurídica"),
+            ("03", "DIMEX"),
+            ("04", "NITE"),
+            ("05", "Extranjero No Domiciliado"),
+            ("06", "No Contribuyente"),
         ]
 
     def action_fetch_hacienda_identification(self):

--- a/hacienda/security/ir.model.access.csv
+++ b/hacienda/security/ir.model.access.csv
@@ -5,3 +5,4 @@ access_hacienda_measurement_unit_user,Hacienda Measurement Unit,model_hacienda_m
 access_hacienda_canton_user,Hacienda Canton,model_hacienda_canton,base.group_user,1,0,0,0
 access_hacienda_district_user,Hacienda District,model_hacienda_district,base.group_user,1,0,0,0
 access_hacienda_neighborhood_user,Hacienda Neighborhood,model_hacienda_neighborhood,base.group_user,1,0,0,0
+access_hacienda_move_payment_method_user,Hacienda Move Payment Method,model_hacienda_move_payment_method,base.group_user,1,1,1,0

--- a/hacienda/views/account_move_views.xml
+++ b/hacienda/views/account_move_views.xml
@@ -1,0 +1,41 @@
+<odoo>
+    <record id="view_move_form_hacienda" model="ir.ui.view">
+        <field name="name">account.move.form.hacienda</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet/notebook" position="inside">
+                <page string="Hacienda" name="cr_hacienda">
+                    <group>
+                        <group>
+                            <field name="cr_sale_condition"/>
+                            <field name="cr_sale_condition_other"
+                                   attrs="{'invisible': [('cr_sale_condition', '!=', '99')], 'required': [('cr_sale_condition', '=', '99')]}"/>
+                            <field name="cr_credit_term"
+                                   attrs="{'invisible': [('cr_sale_condition', 'not in', ('02', '10'))], 'required': [('cr_sale_condition', 'in', ('02', '10'))]}"/>
+                        </group>
+                    </group>
+                    <group>
+                        <field name="cr_payment_method_line_ids" nolabel="1" context="{'default_move_id': active_id}">
+                            <tree editable="bottom">
+                                <field name="sequence" invisible="1"/>
+                                <field name="payment_method"/>
+                                <field name="description"
+                                       attrs="{'invisible': [('payment_method', '!=', '99')], 'required': [('payment_method', '=', '99')]}"/>
+                                <field name="amount" widget="monetary"/>
+                            </tree>
+                            <form>
+                                <group>
+                                    <field name="payment_method"/>
+                                    <field name="description"
+                                           attrs="{'invisible': [('payment_method', '!=', '99')], 'required': [('payment_method', '=', '99')]}"/>
+                                    <field name="amount" widget="monetary"/>
+                                </group>
+                            </form>
+                        </field>
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- align journal, tax, and partner catalog codes with Hacienda XML v4.4 enumerations
- add Costa Rican sale condition and payment method management to invoices, including new O2M model and form page
- expose the new invoice fields in the UI and grant access for payment method records

## Testing
- python -m compileall hacienda

------
https://chatgpt.com/codex/tasks/task_e_68e617a6a94083268ab11d2dcefe701f