### PR TITLE
Make signxml dependency optional in manifest

### DIFF
--- a/hacienda/__manifest__.py
+++ b/hacienda/__manifest__.py
@@ -7,7 +7,12 @@
     "author": "OpenAI Assistant",
     "website": "https://www.hacienda.go.cr/",
     "license": "LGPL-3",
-    "external_dependencies": {"python": ["signxml", "cryptography", "lxml"]},
+    # ``signxml`` is imported lazily only when generating signed XML payloads.
+    # Leaving it out of the external dependency list prevents the module
+    # installation from failing on instances where the package is not yet
+    # available (e.g., minimal staging environments).  Users will still receive
+    # a clear error message at runtime if the optional dependency is missing.
+    "external_dependencies": {"python": ["cryptography", "lxml"]},
     "depends": [
         "base",
         "account",


### PR DESCRIPTION
## Summary
- drop the hard manifest requirement on the `signxml` package so the module can install without it
- document in the manifest that the library is imported lazily during XML signing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e62393b54883268797a3ec524db8df