### PR TITLE
Remove invalid sequence field from Hacienda payment methods tree

### DIFF
--- a/hacienda/views/account_move_views.xml
+++ b/hacienda/views/account_move_views.xml
@@ -18,7 +18,6 @@
                     <group>
                         <field name="cr_payment_method_line_ids" nolabel="1" context="{'default_move_id': active_id}">
                             <tree editable="bottom">
-                                <field name="sequence" invisible="1"/>
                                 <field name="payment_method"/>
                                 <field name="description"
                                        attrs="{'invisible': [('payment_method', '!=', '99')], 'required': [('payment_method', '=', '99')]}"/>


### PR DESCRIPTION
## Summary
- remove the unused `sequence` field from the Hacienda payment methods one2many tree view to avoid referencing a non-existent account.move field

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e62ceda29883268a8531937bbd9dae