### PR TITLE
Fix hacienda payment method view field name

### DIFF
--- a/hacienda/models/account_move.py
+++ b/hacienda/models/account_move.py
@@ -337,7 +337,7 @@ class AccountMove(models.Model):
     def _append_payment_methods(self, resumen, currency):
         for payment in self.cr_payment_method_line_ids:
             medio = etree.SubElement(resumen, "MedioPago")
-            etree.SubElement(medio, "TipoMedioPago").text = payment.payment_method
+            etree.SubElement(medio, "TipoMedioPago").text = payment.code
             if payment.amount:
                 etree.SubElement(medio, "MontoPago").text = self._format_decimal(payment.amount, currency)
             if payment.description:
@@ -542,9 +542,9 @@ class HaciendaMovePaymentMethod(models.Model):
         required=True,
         ondelete="cascade",
     )
-    payment_method = fields.Selection(
+    code = fields.Selection(
         selection=lambda self: self._selection_hacienda_payment_method(),
-        string="Medio de pago",
+        string="Código del medio de pago",
         required=True,
     )
     description = fields.Char(
@@ -582,10 +582,10 @@ class HaciendaMovePaymentMethod(models.Model):
             ("99", "Otros"),
         ]
 
-    @api.constrains("payment_method", "description")
+    @api.constrains("code", "description")
     def _check_description_required(self):
         for line in self:
-            if line.payment_method == "99" and not line.description:
+            if line.code == "99" and not line.description:
                 raise ValidationError(
                     "Debe indicar el detalle del medio de pago cuando utilice el código 'Otros'."
                 )

--- a/hacienda/views/account_move_views.xml
+++ b/hacienda/views/account_move_views.xml
@@ -18,16 +18,16 @@
                     <group>
                         <field name="cr_payment_method_line_ids" nolabel="1" context="{'default_move_id': active_id}">
                             <tree editable="bottom">
-                                <field name="payment_method"/>
+                                <field name="code"/>
                                 <field name="description"
-                                       attrs="{'invisible': [('payment_method', '!=', '99')], 'required': [('payment_method', '=', '99')]}"/>
+                                       attrs="{'invisible': [('code', '!=', '99')], 'required': [('code', '=', '99')]}"/>
                                 <field name="amount" widget="monetary"/>
                             </tree>
                             <form>
                                 <group>
-                                    <field name="payment_method"/>
+                                    <field name="code"/>
                                     <field name="description"
-                                           attrs="{'invisible': [('payment_method', '!=', '99')], 'required': [('payment_method', '=', '99')]}"/>
+                                           attrs="{'invisible': [('code', '!=', '99')], 'required': [('code', '=', '99')]}"/>
                                     <field name="amount" widget="monetary"/>
                                 </group>
                             </form>


### PR DESCRIPTION
## Summary
- rename the Hacienda payment method line selection field to avoid conflicts with account.move during view validation
- update the inline tree/form views and XML generation to use the new field name

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e69634ffc083269104e47821ca16c0